### PR TITLE
Implement labeled failure as combinators and remove some combinators

### DIFF
--- a/src/test/scala/com/github/kmizu/scomb/RegularExpressionSpec.scala
+++ b/src/test/scala/com/github/kmizu/scomb/RegularExpressionSpec.scala
@@ -70,7 +70,7 @@ class RegularExpressionSpec extends FunSpec with DiagrammedAssertions {
       input = "(1|9)*"
       assert(parse(input) == Result.Success(Repeat(Choice(Value('1'), Value('9')))))
       input = "*"
-      assert(parse(input) == Result.Failure(Location(1, 1), "expected:`\\`"))
+      assert(parse(input) == Result.Failure(Location(1, 1), "expected:`\\` actual:`*`"))
     }
   }
 }


### PR DESCRIPTION
- About labeled failure, see: https://arxiv.org/abs/1405.6646
- Add `labeled`, `l~`, `
  - For labeled failure
- Remove `withErrorMessage`, `commit`
  - **breaking change**
  - Because these methods conflict with labeled failure
- Improve parsing error message